### PR TITLE
4 change footer

### DIFF
--- a/packages/berlin/src/data/footer.ts
+++ b/packages/berlin/src/data/footer.ts
@@ -1,30 +1,6 @@
 const footer = {
-  copy: [
-    { id: 0, text: 'A grants program funded by Plurality Labs and the Arbitrum DAO' },
-    { id: 1, text: 'Co-sponsored by RadicalXChange, MetaGov & De-Sci Foundation' },
-    { id: 2, text: 'Tooling built by Lexicon Governance' },
-  ],
+  copy: [{ id: 2, text: 'Tooling built by Lexicon Governance' }],
   logos: [
-    {
-      src: `arbitrum`, // src here its just the filename as we render it as `/logo/${src}-{theme}.svg`
-      alt: 'Arbitrum',
-      link: 'https://arbitrum.foundation/grants',
-    },
-    {
-      src: `radicalxchange`,
-      alt: 'RadicalXChange',
-      link: 'https://www.radicalxchange.org/',
-    },
-    {
-      src: `metagov`,
-      alt: 'MetaGov',
-      link: 'https://metagov.org/',
-    },
-    {
-      src: `desci`,
-      alt: 'De-Sci Foundation',
-      link: 'https://www.descifoundation.org/',
-    },
     {
       src: `lexicon`,
       alt: 'Lexicon Governance',

--- a/packages/berlin/src/layout/Layout.styled.tsx
+++ b/packages/berlin/src/layout/Layout.styled.tsx
@@ -1,8 +1,14 @@
 import styled from 'styled-components';
 
+export const Content = styled.div`
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+`;
+
 export const Main = styled.main`
+  flex: 1;
   margin-inline: auto;
-  min-height: calc(100vh - 21.5rem);
   padding-block: 4rem;
   width: min(90%, 1080px);
 `;

--- a/packages/berlin/src/layout/Layout.tsx
+++ b/packages/berlin/src/layout/Layout.tsx
@@ -3,7 +3,7 @@ import { Toaster } from 'react-hot-toast';
 import { Outlet } from 'react-router-dom';
 
 // Styled components
-import { Main } from './Layout.styled';
+import { Content, Main } from './Layout.styled';
 
 // Components
 import Header from '../components/header';
@@ -13,11 +13,13 @@ function Layout() {
   return (
     <>
       <Toaster position="top-center" toastOptions={{ style: { fontFamily: 'Raleway' } }} />
-      <Header />
-      <Main>
-        <Outlet />
-      </Main>
-      <Footer />
+      <Content>
+        <Header />
+        <Main>
+          <Outlet />
+        </Main>
+        <Footer />
+      </Content>
     </>
   );
 }


### PR DESCRIPTION
## Closes: #4
- Remove logos and text
- Updates layout css and structure, changing the approach of a `min-height: calc(100vh-x);` where x is the sum of header and footer height, to a flex approach, giving <Main> a `flex: 1` property, allowing it to the whole available space of a  `<Content>` with a `min-height: 100vh`

## Evidence:
![image](https://github.com/lexicongovernance/edge-esmeralda/assets/59750365/a0871180-9bb9-4bed-9e55-b67e98042219)
